### PR TITLE
Release/v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,30 +1,36 @@
 # Change Log
 
+## [0.5.0] - 2021-03-25
+
+### Changed
+
+* Ignore inactive workflows [#59](https://github.com/yuya-takeyama/github-actions-metrics-to-datadog-action/pull/59)
+
 ## [0.4.0] - 2021-02-23
 
 ### Added
 
-* Implement repository workflows billing metrics
+* Implement repository workflows billing metrics [#36](https://github.com/yuya-takeyama/github-actions-metrics-to-datadog-action/pull/36)
 
 ## [0.3.0] - 2021-01-30
 
 ### Added
 
-* Now billing metrics can be collected using `schedule` event too
+* Now billing metrics can be collected using `schedule` event too [#20](https://github.com/yuya-takeyama/github-actions-metrics-to-datadog-action/pull/20)
 
 ## [0.2.1] - 2021-01-30
 
 ### Bug Fixes
 
-* Let workflow run be failed correctly
+* Let workflow run be failed correctly [#16](https://github.com/yuya-takeyama/github-actions-metrics-to-datadog-action/pull/16)
 
 ## [0.2.0] - 2021-01-17
 
 ### Added
 
-* Implement billing metrics
+* Implement billing metrics [#10](https://github.com/yuya-takeyama/github-actions-metrics-to-datadog-action/pull/10)
 
 ## [0.1.0] - 2021-01-11
 
 * Initial release
-* Implement `github.actions.workflow_duration`
+* Implement `github.actions.workflow_duration` [#1](https://github.com/yuya-takeyama/github-actions-metrics-to-datadog-action/pull/1)

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ jobs:
   actions-metrics:
     runs-on: ubuntu-latest
     steps:
-      - uses: yuya-takeyama/github-actions-metrics-to-datadog-action@v0.4.0
+      - uses: yuya-takeyama/github-actions-metrics-to-datadog-action@v0.5.0
         with:
           github-token: ${{ secrets.OWNER_GITHUB_TOKEN }}
           datadog-api-key: ${{ secrets.DATADOG_API_KEY }}
@@ -42,7 +42,7 @@ jobs:
   actions-billing-metrics:
     runs-on: ubuntu-latest
     steps:
-      - uses: yuya-takeyama/github-actions-metrics-to-datadog-action@v0.4.0
+      - uses: yuya-takeyama/github-actions-metrics-to-datadog-action@v0.5.0
         with:
           github-token: ${{ secrets.OWNER_GITHUB_TOKEN }}
           datadog-api-key: ${{ secrets.DATADOG_API_KEY }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yuya-takeyama/github-actions-metrics-to-datadog-action",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "private": true,
   "description": "Send metrics of GitHub Actions to Datadog",
   "main": "lib/main.js",


### PR DESCRIPTION
## [0.5.0] - 2021-03-25

### Changed

* Ignore inactive workflows [#59](https://github.com/yuya-takeyama/github-actions-metrics-to-datadog-action/pull/59)
